### PR TITLE
Migrate dependabot reviewers  to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/workflows/ @tecpromotion

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,5 @@ updates:
     schedule:
       interval: "daily"
       time: "09:00"
-    reviewers:
-      - "tecpromotion"
     assignees:
       - "tecpromotion"


### PR DESCRIPTION
Migrate dependabot reviewers from dependabot configuration to `CODEOWNERS` https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
